### PR TITLE
Fix/list domains

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -146,8 +146,9 @@ function listDomainsWithoutRetry() {
             if (token) {
                 prefs.token = token;
             }
-            var tr = h("table.table-striped tbody tr");
-            for (var i = 0; i < tr.length; i++) {
+            var trs = h("table.table-striped tbody tr");
+            for (var i = 0; i < trs.length; i++) {
+                var tr = trs[0];
                 var name = h(tr).find("td.second").text().trim();
                 var reg = h(tr).find("td.third").text();
                 var expiry = h(tr).find("td.fourth").text();

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -148,7 +148,7 @@ function listDomainsWithoutRetry() {
             }
             var trs = h("table.table-striped tbody tr");
             for (var i = 0; i < trs.length; i++) {
-                var tr = trs[0];
+                var tr = trs[i];
                 var name = h(tr).find("td.second").text().trim();
                 var reg = h(tr).find("td.third").text();
                 var expiry = h(tr).find("td.fourth").text();


### PR DESCRIPTION
Currently, you obtain a list of domains with all information repeated in each item.
For example, if you have the domains `a.com` and `b.com` you will obtain:
```
[{
  name: 'a.com b.com',
  ...
}, {
  name: 'a.com b.com',
  ...
}]
```
And the expected result is: 
```
[{
  name: 'a.com',
  ...
}, {
  name: 'b.com',
  ...
}]
```